### PR TITLE
Fix encoding of post body.

### DIFF
--- a/src/org/musicbrainz/webservice/impl/HttpClientWebServiceWs2.java
+++ b/src/org/musicbrainz/webservice/impl/HttpClientWebServiceWs2.java
@@ -1,5 +1,6 @@
 package org.musicbrainz.webservice.impl;
 
+import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
@@ -185,19 +186,12 @@ public class HttpClientWebServiceWs2 extends DefaultWebServiceWs2
         HttpClient httpClient = setConnectionParam(true);
 
         HttpPost method = new HttpPost(url);
-  
-        try {
 
-            StringEntity httpentity = new StringEntity(getWriter().getXmlString(md));
-            httpentity.setContentType(new BasicHeader("Content-Type", "application/xml; charset=UTF-8"));
+        StringEntity httpentity = new StringEntity(getWriter().getXmlString(md), Consts.UTF_8);
+        httpentity.setContentType(new BasicHeader("Content-Type", "application/xml; charset=UTF-8"));
 
-            method.setEntity(httpentity);
-            return executeMethod(httpClient, method);
-            
-         } catch (IOException ex) {
-            Logger.getLogger(HttpClientWebServiceWs2.class.getName()).log(Level.SEVERE, null, ex);
-        } 
-        return null;
+        method.setEntity(httpentity);
+        return executeMethod(httpClient, method);
     }
     @Override
     protected Metadata doPut(String url) throws WebServiceException, MbXMLException {

--- a/test/org/musicbrainz/junit/UnitTests.java
+++ b/test/org/musicbrainz/junit/UnitTests.java
@@ -256,6 +256,37 @@ public class UnitTests {
         System.out.println(artist.getUserRating().getAverageRating());
     }
 
+    /**
+     * Tests if the correct encoding is used for tag submission.
+     * See https://github.com/schnatterer/musicbrainzws2-java/pull/2 for details.
+     */
+    @Test
+    public void AddTagsEncoding() throws MBWS2Exception {
+        ReleaseGroup controller = new ReleaseGroup();
+
+        DefaultWebServiceWs2 ws = new HttpClientWebServiceWs2();
+        ws.setHost(wsHost);
+        controller.setQueryWs(ws);
+        controller.getQueryWs().setUsername(username);
+        controller.getQueryWs().setPassword(password);
+        controller.getQueryWs().setClient(client);
+
+        controller.getIncludes().setUserTags(true);
+
+        ReleaseGroupWs2 releaseGroup = controller.lookUp("686ec242-db40-3713-8f5d-2214e763f515");
+        for (TagWs2 tag : releaseGroup.getUserTags()) {
+            System.out.println(tag.getName());
+        }
+
+        String[] tags = {"progressive", "kayōkyoku"};
+
+        controller.AddTags(tags);
+        controller.lookUp(releaseGroup);
+        for (TagWs2 tag : releaseGroup.getUserTags()) {
+            System.out.println(tag.getName());
+        }
+    }
+
     //@Test
     public void PuidLookUp() throws MBWS2Exception {
 

--- a/test/org/musicbrainz/junit/UnitTests.java
+++ b/test/org/musicbrainz/junit/UnitTests.java
@@ -41,19 +41,22 @@ import org.musicbrainz.webservice.DefaultWebServiceWs2;
 import org.musicbrainz.webservice.impl.HttpClientWebServiceWs2;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static junit.framework.TestCase.assertTrue;
 
 // TODO proper unit test coverage is needed and all commented @test should pass
 public class UnitTests {
 
     static Logger log = Logger.getLogger(UnitTests.class.getName());
 
-    // Note: tests that write, need a valid user/pw pair with validated email on test.musicbrainz.org
-    String username = System.getenv("MB_USER");
-    String password = System.getenv("MB_PW");
+    String username = "test";
+    String password = "mb"; // This is a development server; all passwords have been reset to "mb".
     String wsHost = "test.musicbrainz.org";
     String client = "xxx-1.02beta";
 
@@ -274,17 +277,16 @@ public class UnitTests {
         controller.getIncludes().setUserTags(true);
 
         ReleaseGroupWs2 releaseGroup = controller.lookUp("686ec242-db40-3713-8f5d-2214e763f515");
-        for (TagWs2 tag : releaseGroup.getUserTags()) {
-            System.out.println(tag.getName());
-        }
-
-        String[] tags = {"progressive", "kayōkyoku"};
-
+        
+        String[] tags = {"kayōkyoku" + System.currentTimeMillis()};
         controller.AddTags(tags);
+        
         controller.lookUp(releaseGroup);
+        Set<String> actualTags = new HashSet<String>();
         for (TagWs2 tag : releaseGroup.getUserTags()) {
-            System.out.println(tag.getName());
+            actualTags.add(tag.getName());
         }
+        assertTrue("Tag " + tags[0] + "not contained in list " + actualTags, actualTags.contains(tags[0]));
     }
 
     //@Test


### PR DESCRIPTION
Hi! Thanks for the great library.
I was having issues submitting tags the other day, the tag "kayōkyoku" was always sent as "kay?kyoku".
I did some investigation and found that while the content type header for this request is set to UTF-8, the body uses the default encoding in the StringEntity constructor, which is ISO-8859-1.
This patch changes the encoding of the body to be UTF-8.