### PR TITLE
Fix case of Controller#AddTags

### DIFF
--- a/src/main/java/org/musicbrainz/controller/Controller.java
+++ b/src/main/java/org/musicbrainz/controller/Controller.java
@@ -368,8 +368,7 @@ public abstract class Controller extends DomainsWs2{
     
     // ------------- Submission --------------------------------------------//
        
-    public final void AddTags(String[] userTags) throws MBWS2Exception{
-        
+    public final void addTags(String[] userTags) throws MBWS2Exception {
         for (String tag : userTags)
         {
             TagWs2 t = new TagWs2();
@@ -377,6 +376,13 @@ public abstract class Controller extends DomainsWs2{
             entity.addUserTag(t);
         }
         postUserTags();
+    }
+
+    /**
+     * @deprecated Replaced by {@link #addTags(String[])}.
+     */
+    public final void AddTags(String[] userTags) throws MBWS2Exception {
+        addTags(userTags);
     }
     
     public final void postUserTags() throws MBWS2Exception{

--- a/src/test/java/org/musicbrainz/junit/UnitTests.java
+++ b/src/test/java/org/musicbrainz/junit/UnitTests.java
@@ -230,7 +230,7 @@ public class UnitTests {
 
     @Ignore // Unfortunately, test.musicbrainz.org returns 502
     @Test
-    public void AddTagsAndRating() throws MBWS2Exception {
+    public void addTagsAndRating() throws MBWS2Exception {
 
         Artist controller = new Artist();
 
@@ -252,7 +252,7 @@ public class UnitTests {
 
         String[] tags = {"progressive", "electronic", "english"};
 
-        controller.AddTags(tags);
+        controller.addTags(tags);
         controller.rate(5F);
         controller.lookUp(artist);
         for (TagWs2 tag : artist.getUserTags()) {
@@ -267,7 +267,7 @@ public class UnitTests {
      */
     @Ignore // Unfortunately, test.musicbrainz.org returns 502
     @Test
-    public void AddTagsEncoding() throws MBWS2Exception {
+    public void addTagsEncoding() throws MBWS2Exception {
         ReleaseGroup controller = new ReleaseGroup();
 
         DefaultWebServiceWs2 ws = new HttpClientWebServiceWs2();
@@ -282,8 +282,8 @@ public class UnitTests {
         ReleaseGroupWs2 releaseGroup = controller.lookUp("686ec242-db40-3713-8f5d-2214e763f515");
         
         String[] tags = {"kayōkyoku" + System.currentTimeMillis()};
-        controller.AddTags(tags);
-        
+        controller.addTags(tags);
+
         controller.lookUp(releaseGroup);
         Set<String> actualTags = new HashSet<String>();
         for (TagWs2 tag : releaseGroup.getUserTags()) {


### PR DESCRIPTION
This PR aims to correct the name of `Controller#AddTags` to be `Controller#addTags`. I assume the original spelling was a typo as I did not find any other PascalCase method names.
I kept the original method but deprecated it. it simply delegates to the method with the new name, so any consumer calls will still work.